### PR TITLE
feat: allow solution to config internal system user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ yarn-error.log*
 lerna-debug.log*
 *.pem
 **/instance-types/*
+
+.idea/*

--- a/source/lib/config/user_data/common_user_data
+++ b/source/lib/config/user_data/common_user_data
@@ -102,6 +102,13 @@ cat <<EOF > $DRUID_RUNTIME_CONFIG/emitter_config.json
 {{EMITTER_CONFIG}}
 EOF
 
+# Set up environment variables for Druid to consume
+export METADATA_STORAGE_PASSWORD=$(echo $RDS_SECRET | jq -r .password)
+export DRUID_ADMIN_PASSWORD=$(echo $ADMIN_USER_SECRET | jq -r .password)
+export DRUID_INTERNAL_CLIENT_USERNAME=$(echo $SYSTEM_USER_SECRET | jq -r .username)
+export DRUID_INTERNAL_CLIENT_PASSWORD=$(echo $SYSTEM_USER_SECRET | jq -r .password)
+export DRUID_LOG_DIR=$DRUID_HOME/log
+
 echo " >>druid>> rendering druid configuration $(date)"
 export PYTHONPATH=$DRUID_HOME/scripts/druid
 $PYTHON $DRUID_HOME/scripts/druid/render_druid_config.py \
@@ -120,11 +127,5 @@ $PYTHON $DRUID_HOME/scripts/druid/render_druid_config.py \
     --oidc-group-claim-name {{OIDC_GROUP_CLAIM_NAME}} \
     --druid-base-url {{DRUID_BASE_URL}} \
     --solution-version {{SOLUTION_VERSION}}
-
-# Set up environment variables for Druid to consume
-export METADATA_STORAGE_PASSWORD=$(echo $RDS_SECRET | jq -r .password)
-export DRUID_ADMIN_PASSWORD=$(echo $ADMIN_USER_SECRET | jq -r .password)
-export DRUID_INTERNAL_CLIENT_PASSWORD=$(echo $SYSTEM_USER_SECRET | jq -r .password)
-export DRUID_LOG_DIR=$DRUID_HOME/log
 
 COMMON_CONFIG_VERSION={{COMMON_CONFIG_VERSION}}

--- a/source/lib/uploads/config/_common/common.runtime.properties
+++ b/source/lib/uploads/config/_common/common.runtime.properties
@@ -151,7 +151,7 @@ druid.auth.oidc.clientID={{oidc_client_id}}
 druid.auth.oidc.clientSecret={"type": "environment", "variable": "OIDC_CLIENT_SECRET"}
 druid.auth.oidc.discoveryURI={{oidc_discovery_uri}}
 druid.auth.oidc.druidBaseUrl={{druid_base_url}}
-druid.auth.oidc.druidUsername=druid_system
+druid.auth.oidc.druidUsername={{internal_client_username}}
 druid.auth.oidc.druidPassword={"type": "environment", "variable": "DRUID_INTERNAL_CLIENT_PASSWORD"}
 druid.auth.authenticator.oidc.authorizerName=oidc
 druid.auth.authenticator.jwt.type=jwt
@@ -163,7 +163,7 @@ druid.auth.oidc.groupClaimName={{oidc_group_claim_name}}
 {% endif %}
 
 druid.escalator.type=basic
-druid.escalator.internalClientUsername=druid_system
+druid.escalator.internalClientUsername={{internal_client_username}}
 druid.escalator.internalClientPassword={"type": "environment", "variable": "DRUID_INTERNAL_CLIENT_PASSWORD"}
 druid.escalator.authorizerName=basic
 

--- a/source/lib/uploads/scripts/druid/check_druid_status.py
+++ b/source/lib/uploads/scripts/druid/check_druid_status.py
@@ -37,7 +37,7 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 # common request parameters
 requests_common_params = {
     'verify': False,
-    'auth': ('druid_system', os.getenv('DRUID_INTERNAL_CLIENT_PASSWORD'))
+    'auth': (os.getenv('DRUID_INTERNAL_CLIENT_USERNAME'), os.getenv('DRUID_INTERNAL_CLIENT_PASSWORD'))
 }
 
 

--- a/source/lib/uploads/scripts/druid/render_druid_config.py
+++ b/source/lib/uploads/scripts/druid/render_druid_config.py
@@ -113,7 +113,8 @@ def render_config(
             'oidc_group_claim_name': oidc_group_claim_name,
             'emitter_config': emitter_config,
             'druid_base_url': druid_base_url,
-            'solution_version': solution_version
+            'solution_version': solution_version,
+            'internal_client_username': os.getenv('DRUID_INTERNAL_CLIENT_USERNAME'),
         })
 
         with open(common_runtime_properties_file, mode='w', encoding='utf-8') as outfile:

--- a/source/lib/uploads/scripts/druid/render_utils.py
+++ b/source/lib/uploads/scripts/druid/render_utils.py
@@ -38,7 +38,7 @@ def merge_properties_with_json(properties_file_path, json_file_path):
     filtered_dict = {key: value for key, value in json_data.items(
     ) if not key.startswith("jvm.config.")}
     for key, value in sorted(filtered_dict.items()):
-        if isinstance(value, list):
+        if isinstance(value, list) or isinstance(value, dict):
             properties[key] = json.dumps(value)
         elif isinstance(value, bool):
             properties[key] = str(value).lower()


### PR DESCRIPTION
*This PR enables customisation on druid internal system user, once the cluster is provisioned owner can change the internal system user credentials in secret manager to customise it. The solution now pulls the system user secret and set username/password as environment variables, the variable is then handled in `render_druid_config.py` and `check_druid_status.py` script so it applies to the entire cluster.

We also updated `render_utils.py` to correctly handle `dict` properties. For example previously `"druid.auth.authenticator.allowAll.initialInternalClientPassword": {"type": "environment", "variable": "DRUID_INTERNAL_CLIENT_PASSWORD"}` will be rendered as string into the file (`properties[key] = str(value)`) which makes the final file has {'type': 'environment', 'variable': 'DRUID_INTERNAL_CLIENT_PASSWORD'} property value, this will cause druid to confuse about where to get the value from `INFO [main] org.apache.druid.guice.JsonConfigurator - Unable to parse value of property [druid.auth.authenticator.allowAll.initialInternalClientPassword] as a json object, using as is.`*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
