### PR TITLE
feat: Update zk netplan render to handle docker bridge network interface

### DIFF
--- a/source/lib/config/user_data/zookeeper_user_data
+++ b/source/lib/config/user_data/zookeeper_user_data
@@ -113,7 +113,7 @@ sleep 30
 if [[ ! -z $APT_CMD ]]; then
     ENI_SUBNET_ID=$(echo $ENI_INTERFACE_INFO | jq -r '.NetworkInterfaces[0].SubnetId')
     ENI_MASK_LENGTH=$(aws ec2 describe-subnets --subnet-ids $ENI_SUBNET_ID | jq -r '.Subnets[0].CidrBlock' | awk -F '/' '{print $2}')
-    INTFERFACE_NAME=$(ip -j link show | jq -r '.[] | select(.operstate=="DOWN") | .ifname')
+    INTFERFACE_NAME=$(ip -j link show | jq -r '.[] | select((.ifname | test("^br-") | not) and .operstate == "DOWN") | .ifname')
     DEFAULT_GW_IP=$(ip route | awk '/default/ { print $3 }')
     cat <<EOF > /etc/netplan/99_config.yaml
 network:


### PR DESCRIPTION
Problem: We have noticed when docker has a network interface the zookeeper netplan render is confused and can't correctly pick the ENI ifname. For example with the following network interfaces, the zookeeper_user_data will pick up both br-146bd07d2fbf and eth1 then render into /etc/netplan/99_config.yaml, and the netplan is broken.
```
ip -j link show | jq .
[
  {
    "ifindex": 3,
    "ifname": "br-146bd07d2fbf",
    "flags": [
      "NO-CARRIER",
      "BROADCAST",
      "MULTICAST",
      "UP"
    ],
    "mtu": 1500,
    "qdisc": "noqueue",
    "operstate": "DOWN",
    "linkmode": "DEFAULT",
    "group": "default",
    "link_type": "ether",
    "address": "02:42:01:07:1e:1c",
    "broadcast": "ff:ff:ff:ff:ff:ff"
  },
  {
    "ifindex": 4,
    "ifname": "eth1",
    "flags": [
      "BROADCAST",
      "MULTICAST"
    ],
    "mtu": 1500,
    "qdisc": "noop",
    "operstate": "DOWN",
    "linkmode": "DEFAULT",
    "group": "default",
    "txqlen": 1000,
    "link_type": "ether",
    "address": "0e:f1:0b:65:44:d3",
    "broadcast": "ff:ff:ff:ff:ff:ff"
  }
]
```

Solution: We are adding in additional filtering when finding the INTFERFACE_NAME, so it filter out any docker bridge network interface, which start with "br-".


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
