### PR TITLE
Bump CloudWatch Synthetics runtime version

### DIFF
--- a/source/lib/stacks/druidStack.ts
+++ b/source/lib/stacks/druidStack.ts
@@ -142,7 +142,8 @@ export abstract class DruidStack extends cdk.Stack {
             runtime: new synthetics.Runtime(
                 'syn-nodejs-puppeteer-5.2',
                 synthetics.RuntimeFamily.NODEJS
-            ),            vpc: this.baseInfra.vpc,
+            ),
+            vpc: this.baseInfra.vpc,
             vpcSubnets: { subnets: this.baseInfra.vpc.privateSubnets },
             environmentVariables: { DRUID_ENDPOINT: druidEndpoint },
             test: synthetics.Test.custom({

--- a/source/lib/stacks/druidStack.ts
+++ b/source/lib/stacks/druidStack.ts
@@ -139,8 +139,10 @@ export abstract class DruidStack extends cdk.Stack {
 
     protected createCanary(druidEndpoint: string): synthetics.Canary {
         return new synthetics.Canary(this, 'canary', {
-            runtime: synthetics.Runtime.SYNTHETICS_NODEJS_PUPPETEER_5_1,
-            vpc: this.baseInfra.vpc,
+            runtime: new synthetics.Runtime(
+                'syn-nodejs-puppeteer-5.2',
+                synthetics.RuntimeFamily.NODEJS
+            ),            vpc: this.baseInfra.vpc,
             vpcSubnets: { subnets: this.baseInfra.vpc.privateSubnets },
             environmentVariables: { DRUID_ENDPOINT: druidEndpoint },
             test: synthetics.Test.custom({


### PR DESCRIPTION
*Issue #, if available:*
The CloudWatch Synthetics runtime version **syn-nodejs-puppeteer-5.1** is deprecated on March 8, 2024. As a result, new deployments may fail with the error "the request is invalid. The synthetics runtime version is deprecated" seen in AWS CloudFormation console.

*Description of changes:*
Bump CloudWatch Synthetics runtime version to  **syn-nodejs-puppeteer-5.2**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
