### PR TITLE
feat: Fix the outdated segmentCache selection strategy runtime config

### DIFF
--- a/source/lib/uploads/config/historical/runtime.properties
+++ b/source/lib/uploads/config/historical/runtime.properties
@@ -34,7 +34,7 @@ druid.processing.tmpDir=/mnt/disk2/var/druid/processing
 
 # Segment storage
 druid.segmentCache.locations={{segment_cache_list | safe}}
-druid.segmentCache.locationSelectorStrategy=mostAvailableSize
+druid.segmentCache.locationSelector.strategy=mostAvailableSize
 druid.segmentCache.lazyLoadOnStart=true
 
 # How many segments to drop or load concurrently from deep storage


### PR DESCRIPTION
*Description of changes:*
The default strategy used to select a location to store segment cache is out of date, this PR follows the latest document (https://druid.apache.org/docs/latest/configuration/#storing-segments) and fix the strategy selection.

The changes is tested with the following disk setup, segments are correctly stored onto /mnt/disk3 as it has more available size.
```
/dev/nvme1n1     1.1G   71M  880M   8% /mnt/disk2
/dev/nvme2n1     295G   14M  280G   1% /mnt/disk3
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
