### PR TITLE
feat: Fix log/metrics endpoints when fips enabled

### DIFF
--- a/source/lib/config/user_data/common_user_data
+++ b/source/lib/config/user_data/common_user_data
@@ -70,6 +70,8 @@ echo " >>druid>> starting CloudWatch agent $(date)"
 sed -i \
     -e "s|<DRUID_COMPONENT>|{{DRUID_COMPONENT}}|g" \
     -e "s|<DRUID_CLUSTER_NAME>|{{DRUID_CLUSTER_NAME}}|g" \
+    -e "s|<AWS_REGION>|$AWS_REGION|g" \
+    -e "s|<FIPS_ENDPOINT>|$($AWS_USE_FIPS_ENDPOINT && echo -fips)|g" \
     $DRUID_SOLUTION_CONFIG/cloudwatch-agent/amazon-cloudwatch-agent.json
 /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:$DRUID_SOLUTION_CONFIG/cloudwatch-agent/amazon-cloudwatch-agent.json
 

--- a/source/lib/config/user_data/zookeeper_user_data
+++ b/source/lib/config/user_data/zookeeper_user_data
@@ -56,11 +56,14 @@ mv apache-zookeeper-{{ZK_VERSION}}-bin apache-zookeeper
 
 # Configure CloudWatch agent
 aws s3 cp s3://{{S3_INSTALLATION_BUCKET}}/config/cloudwatch-agent/amazon-cloudwatch-agent.json /opt/aws/amazon-cloudwatch-agent/etc/
-sed -i "s|<DRUID_COMPONENT>|zookeeper|g" /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
-sed -i "s|<DRUID_CLUSTER_NAME>|{{DRUID_CLUSTER_NAME}}|g" /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
 
-# Start CloudWatch agent
 echo " >>zookeeper>> starting CloudWatch agent $(date)"
+sed -i \
+    -e "s|<DRUID_COMPONENT>|zookeeper|g" \
+    -e "s|<DRUID_CLUSTER_NAME>|{{DRUID_CLUSTER_NAME}}|g" \
+    -e "s|<AWS_REGION>|$AWS_REGION|g" \
+    -e "s|<FIPS_ENDPOINT>|$($AWS_USE_FIPS_ENDPOINT && echo -fips)|g" \
+    /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
 /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
 
 # Configure Zookeeper

--- a/source/lib/uploads/config/cloudwatch-agent/amazon-cloudwatch-agent.json
+++ b/source/lib/uploads/config/cloudwatch-agent/amazon-cloudwatch-agent.json
@@ -1,6 +1,7 @@
 {
     "agent": { "metrics_collection_interval": 60 },
     "metrics": {
+        "endpoint_override": "https://monitoring<FIPS_ENDPOINT>.<AWS_REGION>.amazonaws.com",
         "namespace": "AWSSolutions/Druid",
         "metrics_collected": {
             "cpu": {
@@ -44,6 +45,7 @@
         "force_flush_interval": 30
     },
     "logs": {
+        "endpoint_override": "https://logs<FIPS_ENDPOINT>.<AWS_REGION>.amazonaws.com",
         "logs_collected": {
             "files": {
                 "collect_list": [

--- a/source/package-lock.json
+++ b/source/package-lock.json
@@ -4865,15 +4865,9 @@
             "dev": true
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.4",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-            "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
+            "version": "1.15.6",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/follow-redirects/-/follow-redirects-1.15.6.tgz",
+            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
             "engines": {
                 "node": ">=4.0"
             },
@@ -11260,9 +11254,9 @@
             "dev": true
         },
         "follow-redirects": {
-            "version": "1.15.4",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-            "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw=="
+            "version": "1.15.6",
+            "resolved": "https://packages.atlassian.com/api/npm/npm-remote/follow-redirects/-/follow-redirects-1.15.6.tgz",
+            "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
         },
         "form-data": {
             "version": "4.0.0",


### PR DESCRIPTION
*Description of changes:*

Currently when setting AWS_USE_FIPS_ENDPOINT the cloudwatch agent doesn't use fips endpoints, this PR adds logic to adopt the correct fips and region endpoints for cloudwatch agent to send logs and metrics.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
