### PR TITLE
feat: Add vpc to all lambdas, allow users to self manage install bucket assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,23 @@ The Federal Information Processing Standard ([FIPS](https://aws.amazon.com/compl
 "useFipsEndpoint": true,
 ```
 
+**Self-managed druid installation bucket asset (optional)**
+
+By default, the solution will upload druid binary, extension, config and scripts to s3 bucket automatically, optionally you can manage these assets yourself by using below configuration
+
+```
+"selfManageInstallationBucketAssets": true,
+```
+When this option is enabled, you will need to manually upload assets in the following folders to s3 bucket after you `npm run build`
+```
+source/lib/uploads/scripts/ -> bootstrap-s3-bucket-installation/scripts/
+source/lib/docker/extensions/ -> bootstrap-s3-bucket-installation/extensions/
+source/lib/uploads/config/ -> bootstrap-s3-bucket-installation/config/
+source/lib/docker/ca-certs/ -> bootstrap-s3-bucket-installation/ca-certs/
+source/druid-bin/ -> bootstrap-s3-bucket-installation/druid-images/
+source/zookeeper-bin/ -> bootstrap-s3-bucket-installation/zookeeper-images/
+```
+
 **Identity provider configuration (optional)**
 The default setup of this solution activates basic authentication, enabling access to the Druid web console and API through a username and password. Additionally, you have the option to enable user access federation through a third-party identity provider (IdP) that supports OpenID Connect authentication. If you have an existing enterprise Identity Provider, you can seamlessly integrate it using the CDK configuration outlined below.
 

--- a/source/bin/druid-infra.ts
+++ b/source/bin/druid-infra.ts
@@ -84,6 +84,7 @@ const contextKeys: (keyof DruidConfig)[] = [
     'druidInstanceIamPolicyArns',
     'tags',
     'additionalTags',
+    'selfManageInstallationBucketAssets',
 ];
 
 const configMap: Record<string, unknown> = {};
@@ -171,6 +172,7 @@ const commonStackProps = {
     customAmi: druidConfig.customAmi,
     subnetMappings: druidConfig.subnetMappings,
     enableVulnerabilityScanJob: druidConfig.enableVulnerabilityScanJob ?? false,
+    selfManageInstallationBucketAssets: druidConfig.selfManageInstallationBucketAssets ?? false,
     ...(!druidConfig.environmentAgnostic && { env: { account, region } }),
 };
 

--- a/source/lib/constructs/configScheme.ts
+++ b/source/lib/constructs/configScheme.ts
@@ -275,6 +275,12 @@ export const configScheme = {
             $id: '#/properties/enableVulnerabilityScanJob',
             description: 'Whether to enable vulnerability scan job.',
         },
+        selfManageInstallationBucketAssets: {
+            type: 'boolean',
+            title: 'Enable self management for installation bucket assets',
+            $id: '#/properties/selfManageInstallationBucketAssets',
+            description: 'Whether to enable self management for installation bucket assets.',
+        },
         environmentAgnostic: {
             type: 'boolean',
             title: 'Environment Agnostic',

--- a/source/lib/constructs/internalCertificateAuthority.ts
+++ b/source/lib/constructs/internalCertificateAuthority.ts
@@ -17,6 +17,7 @@
 
 import * as cdk from 'aws-cdk-lib';
 import * as cr from 'aws-cdk-lib/custom-resources';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as kms from 'aws-cdk-lib/aws-kms';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as lambdaNodejs from 'aws-cdk-lib/aws-lambda-nodejs';
@@ -25,10 +26,14 @@ import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
 
 import { Construct } from 'constructs';
 
+export interface InternalCertificateAuthorityProps {
+    vpc: ec2.IVpc;
+}
+
 export class InternalCertificateAuthority extends Construct {
   public readonly TlsCertificate: secretsmanager.ISecret;
 
-  public constructor(scope: Construct, id: string) {
+  public constructor(scope: Construct, id: string, props: InternalCertificateAuthorityProps) {
     super(scope, id);
 
     this.TlsCertificate = new secretsmanager.Secret(this, 'tls-certificate', {
@@ -44,6 +49,10 @@ export class InternalCertificateAuthority extends Construct {
       this,
       'tls-generator-handler',
       {
+        vpc: props.vpc,
+        vpcSubnets: {
+            subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
+        },
         entry: path.join(__dirname, '../lambdas/certificateGenerator.ts'),
         handler: 'onEventHandler',
         runtime: lambda.Runtime.NODEJS_LATEST,

--- a/source/lib/constructs/operationalMetricCollection.ts
+++ b/source/lib/constructs/operationalMetricCollection.ts
@@ -15,6 +15,7 @@
 */
 import * as cdk from 'aws-cdk-lib';
 import * as cr from 'aws-cdk-lib/custom-resources';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as path from 'path';
 
@@ -24,6 +25,7 @@ import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
 import { addCfnNagSuppression } from './cfnNagSuppression';
 
 export interface OperationalMetricsCollectionProps {
+    vpc: ec2.IVpc;
     awsSolutionId: string;
     awsSolutionVersion: string;
     retainData: boolean;
@@ -44,6 +46,10 @@ export class OperationalMetricsCollection extends Construct {
         super(scope, id);
 
         const fn = new NodejsFunction(this, 'operational-metrics-handler', {
+            vpc: props.vpc,
+            vpcSubnets: {
+                subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
+            },
             entry: path.join(__dirname, './operationMetricCollectionLambda.ts'),
             handler: 'handler',
             description: 'Lambda for Operational Metrics collection',

--- a/source/lib/stacks/druidEksStack.ts
+++ b/source/lib/stacks/druidEksStack.ts
@@ -87,6 +87,7 @@ export class DruidEksStack extends DruidStack {
         }
 
         new OperationalMetricsCollection(this, 'metrics-collection', {
+            vpc: this.baseInfra.vpc,
             awsSolutionId: props.solutionId,
             awsSolutionVersion: props.solutionVersion,
             druidVersion: props.clusterParams.druidVersion,

--- a/source/lib/stacks/druidStack.ts
+++ b/source/lib/stacks/druidStack.ts
@@ -46,6 +46,7 @@ export abstract class DruidStack extends cdk.Stack {
             vpcCidr: props.vpcId ? undefined : props.vpcCidr, // don't set cidr for byo vpc
             initBastion: props.initBastion,
             initInstallationBucket: props.initInstallationBucket,
+            selfManageInstallationBucketAssets: props.selfManageInstallationBucketAssets,
             druidClusterName: props.clusterParams.druidClusterName,
             druidDeepStorageConfig: props.clusterParams.druidDeepStorageConfig,
             oidcIdpConfig: props.clusterParams.oidcIdpConfig,
@@ -111,6 +112,7 @@ export abstract class DruidStack extends cdk.Stack {
 
         cdk.Aspects.of(this).add(
             new AppRegistry(this, 'app-registry-aspect', {
+                vpc: this.baseInfra.vpc,
                 solutionId: props.solutionId,
                 solutionVersion: props.solutionVersion,
                 solutionName: props.solutionName,

--- a/source/lib/utils/types.ts
+++ b/source/lib/utils/types.ts
@@ -70,6 +70,7 @@ export interface DruidConfig {
     readonly retainData?: boolean;
     readonly enableVulnerabilityScanJob?: boolean;
     readonly environmentAgnostic?: boolean;
+    readonly selfManageInstallationBucketAssets?: boolean;
 
     readonly druidClusterName: string;
     readonly druidVersion: string;
@@ -98,6 +99,7 @@ export interface DruidStackProps extends cdk.StackProps {
     readonly vpcCidr?: string;
     readonly initBastion?: boolean;
     readonly initInstallationBucket?: boolean;
+    readonly selfManageInstallationBucketAssets?: boolean;
     readonly route53Params?: {
         readonly route53HostedZoneId: string;
         readonly route53HostedZoneName: string;


### PR DESCRIPTION
*Description of changes:*

This PR
- Adds vpc to all lambdas to enhance security (without it the lambda will run on lambda vpc which has access to public internet)
- Adds a selfManageInstallationBucketAssets prop to allow self management on druid installation assets (scripts, extension and druid image etc)

The changes is tested on
- A existing ec2 stack, the lambdas are updated to use the correct vpc, and bucketDeployment are correctly disabled by turning on selfManageInstallationBucketAssets

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
