### PR TITLE
fix: setup nvme disk for data/historical/middlemanager

### DIFF
--- a/source/lib/config/user_data/data_user_data
+++ b/source/lib/config/user_data/data_user_data
@@ -12,11 +12,12 @@ do
     mount -t ext4 $NVME_PATH $MOUNT_POINT
     echo "$NVME_PATH $MOUNT_POINT auto noatime 0 0" | tee -a /etc/fstab
     mkdir -p $MOUNT_POINT/var/druid/druidSegments
+    mkdir -p $MOUNT_POINT/var/tmp
+    mkdir -p $MOUNT_POINT/var/druid/task
+    mkdir -p $MOUNT_POINT/var/druid/processing
     chown -R ${USER_NAME}:${USER_NAME} $MOUNT_POINT
     PATH_INDEX=$(expr $PATH_INDEX + 1)
 done
-
-mkdir -p /mnt/disk2/var/tmp /mnt/disk2/var/druid/task /mnt/disk2/var/druid/processing
 
 sh -c 'echo "* soft nofile 800000" >> /etc/security/limits.conf'
 sh -c 'echo "* hard nofile 800000" >> /etc/security/limits.conf'

--- a/source/lib/config/user_data/historical_user_data
+++ b/source/lib/config/user_data/historical_user_data
@@ -11,6 +11,9 @@ do
     mount -t ext4 $NVME_PATH $MOUNT_POINT
     echo "$NVME_PATH $MOUNT_POINT auto noatime 0 0" | tee -a /etc/fstab
     mkdir -p $MOUNT_POINT/var/druid/druidSegments
+    mkdir -p $MOUNT_POINT/var/tmp
+    mkdir -p $MOUNT_POINT/var/druid/task
+    mkdir -p $MOUNT_POINT/var/druid/processing
     chown -R ${USER_NAME}:${USER_NAME} $MOUNT_POINT
     PATH_INDEX=$(expr $PATH_INDEX + 1)
 done

--- a/source/lib/config/user_data/middleManager_user_data
+++ b/source/lib/config/user_data/middleManager_user_data
@@ -1,10 +1,22 @@
 {{COMMON_USER_DATA}}
 MIDDLEMANAGER_CONFIG_VERSION={{MIDDLEMANAGER_CONFIG_VERSION}}
 
-mkdir -p /mnt/disk2/var/tmp
-mkdir -p /mnt/disk2/var/druid/task
-mkdir -p /mnt/disk2/var/druid/processing
-sudo chown -R ${USER_NAME}:${USER_NAME} /mnt/disk2/
+echo " >>druid>> mounting NVME disks $(date)"
+PATH_INDEX=2
+for NVME_PATH in $(nvme list -o json | jq '.Devices | map(select(.DevicePath != "/dev/nvme0n1").DevicePath) | sort | join(" ")' | tr -d '"')
+do
+    MOUNT_POINT=/mnt/disk${PATH_INDEX}
+    mkdir -p $MOUNT_POINT
+    mkfs.ext4 $NVME_PATH
+    mount -t ext4 $NVME_PATH $MOUNT_POINT
+    echo "$NVME_PATH $MOUNT_POINT auto noatime 0 0" | tee -a /etc/fstab
+    mkdir -p $MOUNT_POINT/var/druid/druidSegments
+    mkdir -p $MOUNT_POINT/var/tmp
+    mkdir -p $MOUNT_POINT/var/druid/task
+    mkdir -p $MOUNT_POINT/var/druid/processing
+    chown -R ${USER_NAME}:${USER_NAME} $MOUNT_POINT
+    PATH_INDEX=$(expr $PATH_INDEX + 1)
+done
 
 cp -rf $DRUID_SOLUTION_CONFIG/middleManager $DRUID_CLUSTER_CONFIG/data/
 


### PR DESCRIPTION
*Description of changes:*

we recently noticed the solution is creating task and processing folders for middle manager using a hard coded approach (`/mnt/disk2`), in some cases, we want to choose which disk to use by setting runtime.properties i.e. `"druid.worker.baseTaskDirs": ["/mnt/disk3/var/druid/task"]`

this PR 
- makes sure the solution creates tmp, task and processing folders on all disks to make it possible to config task dir
- makes sure when running middlaManager alone the user_data also mounts disks and creates folders

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
