### PR TITLE
Fix Data Node Splitting in Tiers

### DIFF
--- a/source/lib/constructs/druidAutoScalingGroup.ts
+++ b/source/lib/constructs/druidAutoScalingGroup.ts
@@ -176,8 +176,9 @@ export class DruidAutoScalingGroup extends Construct {
             historicalInstanceConfig.instanceType
         );
 
+        const nodeTierName = utils.getNodeTierName(props.nodeType, props.serviceTier);
         const instanceTypeInfo = utils.getInstanceTypeInfo(
-            ec2Config[props.nodeType]?.instanceType ?? ''
+            ec2Config[nodeTierName]?.instanceType ?? ''
         );
 
         const templateVariables: Record<string, string> = {
@@ -197,7 +198,7 @@ export class DruidAutoScalingGroup extends Construct {
             ),
             DRUID_VERSION: asgContext.clusterParams.druidVersion,
             DRUID_EXTENSIONS: JSON.stringify(asgContext.clusterParams.druidExtensions),
-            DRUID_COMPONENT: utils.getNodeTierName(props.nodeType, props.serviceTier),
+            DRUID_COMPONENT: nodeTierName,
             REGION: cdk.Aws.REGION,
             STACK_NAME: cdk.Aws.STACK_NAME,
             RESOURCE_NAME: (asg.node.defaultChild as as.CfnAutoScalingGroup).logicalId,


### PR DESCRIPTION
## Description of changes:

- This PR fixes the problem that currently splitting the middleManager and historicals into separate tiers only works if both your Tier 1 and Tier 2 nodes have the same name.
  - For example: 
     - Tier 1: `data` | Tier 2: `data_tier2` 👍 
     - Tier 1: `data` | Tier 2: `middleManager_tier2`, `historical_tier2` 👎 (expected to work) 
     - Tier 1: `middleManager`,  `historical` | Tier 2: `middleManager_tier2`, `historical_tier2` 👍 
     - Tier 1: `middleManager`,  `historical` | Tier 2: `data_tier2` 👎  (expected to work)
- The reason is that currently when we get the instance type information we expect the `props.nodeType` to exist which in the case of both tiers having the same node type, it will, otherwise it will not which will cause the deploy to fail since we will not be able to grab the AWS resource information since we will set the parameter to `utils.getInstanceTypeInfo` as an empty string.